### PR TITLE
Fix segfault and errors with M_PI constant when using the g++ compiler on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Lignes pour compiler et lancer le programme
 compile:
 	@mkdir -p build
-	@g++ --std=c++2a src/main.cpp -o build/ocean
+	@g++ --std=c++2a -D_USE_MATH_DEFINES -Ofast src/main.cpp -o build/ocean
 	@build/ocean

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,10 +5,11 @@
 
 int main() {
   using namespace Ocean;
-  Image image(800, 800*9/16);
+  Image image(512, 512*9/16);
 
   GenerateSpectra();
   for (int i = 0; i < 1024; i++) {
+    printf("Saving frame %d...", i);
     UpdateHeights(i*0.016f);
     Draw(image);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@ int main() {
 
   GenerateSpectra();
   for (int i = 0; i < 1024; i++) {
-    printf("Saving frame %d...", i);
+    printf("Saving frame %d...\n", i);
     UpdateHeights(i*0.016f);
     Draw(image);
 

--- a/src/math/Numbers.hpp
+++ b/src/math/Numbers.hpp
@@ -38,10 +38,10 @@ namespace Ocean {
 
   template <typename T>
   T BilinearInterpolation(float x, float y, int width, int height, T *values) {
-    int xi1 = Mod(x, width);
-    int yi1 = Mod(y, height);
-    int xi2 = Mod(x + 1, width);
-    int yi2 = Mod(y + 1, height);
+    int xi1 = Mod(x, width - 1);
+    int yi1 = Mod(y, height - 1);
+    int xi2 = Mod(x + 1, width - 1);
+    int yi2 = Mod(y + 1, height - 1);
 
     T topLeft = values[yi1 + xi1 * width];
     T topRight = values[yi1 + xi2 * width];

--- a/src/rendering/Constants.hpp
+++ b/src/rendering/Constants.hpp
@@ -7,7 +7,7 @@ namespace Ocean {
   Color SKY_COLOR(0.4, 0.75, 1);
   Color SUN_COLOR(1.5, 1, 0.6);
   Direction3 SUN_DIRECTION = Normalize(Vector3(-1.5, -1.2, 0.1));
-  int NUM_SAMPLES = 3; // Increase to reduce noise
+  int NUM_SAMPLES = 3; // Increase to reduce noise on the image (but has a big impact on performance)
 
   constexpr float FOG_INTENSITY = 1.2f;
   constexpr float FOG_DISTANCE = 100.f;

--- a/src/rendering/Constants.hpp
+++ b/src/rendering/Constants.hpp
@@ -7,6 +7,7 @@ namespace Ocean {
   Color SKY_COLOR(0.4, 0.75, 1);
   Color SUN_COLOR(1.5, 1, 0.6);
   Direction3 SUN_DIRECTION = Normalize(Vector3(-1.5, -1.2, 0.1));
+  int NUM_SAMPLES = 3; // Increase to reduce noise
 
   constexpr float FOG_INTENSITY = 1.2f;
   constexpr float FOG_DISTANCE = 100.f;

--- a/src/rendering/Render.hpp
+++ b/src/rendering/Render.hpp
@@ -53,9 +53,9 @@ namespace Ocean {
         float yPixel = float(y) / image.height - 0.5;
 
         Color totalColor;
-        for (int i = 0; i < 10; i++)
+        for (int i = 0; i < NUM_SAMPLES; i++)
           totalColor = totalColor + GeneratePixelColor(xPixel, yPixel);
-        totalColor = totalColor / 10;
+        totalColor = totalColor / NUM_SAMPLES;
 
         Color color = (1.0f - 0.58f * (xPixel * xPixel + yPixel * yPixel)) * totalColor;
         image(x, y) = 1.25 * Color(pow(log(color.x + 1), 1.3),


### PR DESCRIPTION
- When compiling the program on Windows, the M_PI constant is not defined by default, and an additional flag needs to be passed to the compiler: https://stackoverflow.com/questions/26065359/m-pi-flagged-as-undeclared-identifier

- The function `BilinearInterpolation` was accessing data out of the allocated array, which created a SEGFAULT error.